### PR TITLE
Generate .pdf graphs when pandoc format is beamer

### DIFF
--- a/src/PandocFilterGraphviz.hs
+++ b/src/PandocFilterGraphviz.hs
@@ -70,6 +70,7 @@ getCaption m = case M.lookup "caption" m of
 getFmt :: Maybe Format -> String
 getFmt mfmt = case mfmt of
   Just (Format "latex") -> "pdf"
+  Just (Format "beamer") -> "pdf"
   Just _ -> "png"
   Nothing -> "png"
 


### PR DESCRIPTION
When using beamer as pandoc output format, it is better to use .pdf graphs for graphviz output.